### PR TITLE
Fixed broken author image link

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -25,8 +25,7 @@ nav_exclude:                                            # The following paths ar
 ### Author Info ###
 author:
   name              : John Doe
-  #image             : https://bit.ly/2KCvgVJ
-  image             : https://bit.ly/3bQH9kw
+  image             : https://i.imgur.com/uyDNQnn.jpg
   behance           : your_username
 # dribbble          : your_username
   email             : username@domain.com

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -25,7 +25,8 @@ nav_exclude:                                            # The following paths ar
 ### Author Info ###
 author:
   name              : John Doe
-  image             : https://bit.ly/2KCvgVJ
+  #image             : https://bit.ly/2KCvgVJ
+  image             : https://bit.ly/3bQH9kw
   behance           : your_username
 # dribbble          : your_username
   email             : username@domain.com


### PR DESCRIPTION
I noticed that the example author image was not displayed. The host no longer seems to exist. I found the same image and uploaded it on another host ([here](https://imgur.com/uyDNQnn)).

I tried shortening the URL using [bit.ly](http://bit.ly) but using such link didn't work when I tested it. That's why I used the raw URL in the fix.

