### PR TITLE
Upgrade Font Awesome CDN

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,7 @@
   <link rel="shortcut icon" type="image/x-icon" href="{{ '/assets/favicon.ico' | relative_url }}">
 
   <!-- Font Awesome CDN -->
-  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.10.0/css/all.css">
 
   <!-- Bootstrap CSS CDN -->
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">


### PR DESCRIPTION
* The Font Awesome CDN  has ben upgrade to new versions.
* For example, speaker-deck icon don't show on the actual version and are ok to show on v5.10.0

**Issue related**: #31 