### PR TITLE
Add Kaggle to Social Media List

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -33,6 +33,7 @@ author:
   github            : your_username
 # gitlab            : your_username
 # instagram         : your_username
+# kaggle            : your_username
   linkedin          : your_username
   medium            : your_username
 # soundcloud        : your_username

--- a/docs/_data/social-media.yml
+++ b/docs/_data/social-media.yml
@@ -35,6 +35,11 @@ instagram:
   url   : https://www.instagram.com/
   icon  : fab fa-instagram
   color : 405de6
+  
+kaggle:
+  url   : https://www.kaggle.com/
+  icon  : fab fa-kaggle
+  color : 20beff
 
 linkedin:
   url   : https://www.linkedin.com/in/


### PR DESCRIPTION
I wanted to have Kaggle available in the social media list, so I added it to [social-medial.yml](https://github.com/hugolmn/portfolYOU/blob/a229dd7d2dc4e93a711fc3d53ae3df8253003d40/docs/_data/social-media.yml) as well as the [config file](https://github.com/hugolmn/portfolYOU/blob/a229dd7d2dc4e93a711fc3d53ae3df8253003d40/docs/_config.yml).

Tested and it works :)
