### PR TITLE
Fix Shifting Scrollbar Bug

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -1,3 +1,7 @@
+html{
+  padding-left: calc(100vw - 100%);
+}
+
 body {
   font-family: "Poppins", sans-serif;
 }


### PR DESCRIPTION
The landing page doesn't have a scroll bar, therefore whenever we jump to another tab (blog, project, about...), a scrolling bar appears and shifts the page.

This little trick found [here](https://stackoverflow.com/a/30293718) solves it.

Tested [here](https://hugolmn.github.io/)

