### PR TITLE
Add Google Analytics Support

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,11 @@
+{%- if jekyll.environment == 'production' and site.analytics.enabled == true -%}
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics.google.tracking_id }}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '{{ site.analytics.google.tracking_id }}');
+  </script>
+{%- endif -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,6 +18,7 @@
   </main>
 
   {% include footer.html %}
+  {% include analytics.html %}
   {% include scripts.html %}
 
 </body>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -63,6 +63,13 @@ collections:
 disqus: your-short-name-disqus                          # Your website Shortname on disqus
 
 
+### Analytics ###
+analytics:
+  enabled: false                                        # Set true to enable analytics
+  google:
+    tracking_id: your-google-tracking-id
+
+
 ### Defaults for collections ###
 defaults:
   - scope:

--- a/test/_config.yml
+++ b/test/_config.yml
@@ -35,6 +35,13 @@ collections:
     output: true
 
 
+### Analytics ###
+analytics:
+  enabled: true
+  google:
+    tracking_id: google-tracking-id
+
+
 ### Defaults for collections ###
 defaults:
   - scope:


### PR DESCRIPTION
I have been tried to integrate analytics into my blog without touching in this repo, for instance, by using [Jekyll Analytics](https://github.com/hendrikschneider/jekyll-analytics) but it seems that this plugin is not whitelisted by Github, so one alternative is to implement this feature here. 

My suggestion is started by including google analytics and support other providers in the future.

<img width="1004" alt="Screenshot 2020-05-07 at 20 04 02" src="https://user-images.githubusercontent.com/20430410/81328985-1896f400-909e-11ea-891b-47fcaf1b10cc.png">

As a suggestion, I've created this block for analytics and set false by default. 

```yaml
### Analytics ###
analytics:
  enabled: false  # Set true to enable analytics
  google:
    tracking_id: UA-XXXXXXX-1
```

To test, we should use:
`JEKYLL_ENV=production bundle exec jekyll serve`

This PR would close this issue https://github.com/YoussefRaafatNasry/portfolYOU/issues/44