### PR TITLE
Better use of title tag.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="{{ site.description }}">
 
-  <title>{{ site.title }}</title>
+  <title>{% if page.title %} {{ page.title }} {% else %} {{ site.title }} {% endif %}</title>
   <link rel="shortcut icon" type="image/x-icon" href="{{ '/assets/favicon.ico' | relative_url }}">
 
   <!-- Font Awesome CDN -->

--- a/test/_config.yml
+++ b/test/_config.yml
@@ -1,4 +1,5 @@
 ### Site Settings ###
+title               : PortfolYOU
 source              : ../
 collections_dir     : docs
 data_dir            : docs/_data


### PR DESCRIPTION
Title tags are displayed on search engine results pages (SERPs) as the clickable headline for a given result and are important for usability, SEO, and social sharing.

Currently, the title is defined using the variable `site.title` in `_config.yml`, this PR aims to use the page title as default for title tag and fallback to `site.title` when page title is not provided.

I did some tests using my personal blog and noticed better performance when using search engines to find my content.

