### PR TITLE
Activate or Deactivate Disqus per Post

### DIFF
--- a/_includes/blog/disqus.html
+++ b/_includes/blog/disqus.html
@@ -1,7 +1,7 @@
-{%- if site.disqus -%}
+{%- if page.comments != false and jekyll.environment == "production" -%}
   <div id="disqus_thread"></div>
   <script type="text/javascript">
-    var disqus_shortname = '{{ site.disqus }}';
+    var disqus_shortname = '{{ site.disqus.shortname }}';
     (function() {
       var disqus = document.createElement('script');
       disqus.type = 'text/javascript';

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -60,7 +60,8 @@ collections:
 
 
 ### Disqus ###
-disqus: your-short-name-disqus                          # Your website Shortname on disqus
+disqus:
+  shortname: your-short-name-disqus                     # Your website Shortname on disqus
 
 
 ### Defaults for collections ###

--- a/docs/_posts/2016-02-09-what-is-version-control.md
+++ b/docs/_posts/2016-02-09-what-is-version-control.md
@@ -3,6 +3,7 @@ title: What is version control?
 tags: [Version Control]
 style: fill
 color: secondary
+comments: true
 description: Benefits of version control and version control systems.
 ---
 

--- a/docs/documentation/partials/01-features.md
+++ b/docs/documentation/partials/01-features.md
@@ -8,6 +8,7 @@
 - **Automatic** importing for **GitHub Repositories** as Projects.
 - **Search** posts by title, tags or descriptions.
 - **Tags archive** for posts.
+- Disqus support for blog posts.
 - Skills progress bars and education/experience timeline.
 - Support large number of **social networks**.
 - Quick including for various [elements][elements] as videos, lists, figures, buttons and many more.

--- a/test/_config.yml
+++ b/test/_config.yml
@@ -23,8 +23,9 @@ author:
 
 ### Posts ###
 permalink: /blog/:title
-disqus: short-name-disqus
 
+disqus:
+  shortname: your-disqus-shortname
 
 ### Collections ###
 collections:


### PR DESCRIPTION
Add ability to activate and deactivate Disqus comments for blog posts, I think it should close the issue https://github.com/YoussefRaafatNasry/portfolYOU/issues/45

Add in `_config.yml`:
``` yaml
### Disqus ###
disqus:
  shortname: your-short-name-disqus                     # Your website Shortname on disqus
```

Add `comments: true` in the header of the post:
``` yaml
---
title: What is version control?
color: secondary
comments: true
description: Benefits of version control and version control systems.
---
```

The comments are disabled by default.
