### PR TITLE
Fix Typo in Docs' Customization Section

### DIFF
--- a/docs/documentation/partials/03-customization.md
+++ b/docs/documentation/partials/03-customization.md
@@ -9,7 +9,7 @@ Simply **override** the file you want to change by matching the **same file name
 
 **Example 2:** Custom Style
 
-1. Create **`assets/css/styles.scss`**.
+1. Create **`assets/css/style.scss`**.
 1. Add the following lines:
 
     ```css


### PR DESCRIPTION
Just a typo, this should be style.scss