### PR TITLE
feat: make external links in navbar open in new tab

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -51,7 +51,11 @@
           {%- assign url = html_page.url | relative_url -%}
         {%- endif -%}
 
-        <a class="nav-item nav-link {{ active_status }}" href="{{ url }}" target="_blank">{{ html_page.title }}</a>
+        {%- if html_page.external_url -%}
+          <a class="nav-item nav-link {{ active_status }}" href="{{ url }}" target="_blank">{{ html_page.title }}</a>
+        {%- else -%}
+          <a class="nav-item nav-link {{ active_status }}" href="{{ url }}">{{ html_page.title }}</a>
+        {%- endif -%}
 
       {% endfor %}
 


### PR DESCRIPTION
Continually adds `target="_blank"` if the link in the navbar is created by `external_url`. I don't know if this is a feature you want or not, but my use-case was adding a link to my GitHub, which I didn't want to replace the tab that was my website:
```
---
title: <i class="fab fa-github"></i>
external_url: https://github.com/Avery2
weight: 99
---
```