### PR TITLE
Add Open Graph Image Meta Tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
 
   {% assign title = page.title | default: site.title | escape %}
   {% assign description = page.description | default: site.description | strip_html | strip_newlines | truncate: 160 %}
+  {% assign image = page.image | default: site.author.image %}
 
   {% if page.name and page.collection == 'projects' %}
     {% assign title = page.name | escape %}
@@ -14,6 +15,7 @@
   <meta property="og:type" content="website">
   <meta property="og:title" content="{{ title }}">
   <meta property="og:description" content="{{ description }}">
+  <meta property="og:image" content="{{ image }}">
 
   <title>{{ title }}</title>
   <meta name="description" content="{{ description }}">


### PR DESCRIPTION
I tweeted a blog post and noticed it didn't have an image in the preview.

This takes an image from the page front matter if possible, otherwise defaults to the author image. This allows for previews on twitter, discord etc to have an image.

I've tested it locally and on GitHub pages and it seems to work as intended.