### PR TITLE
Added gem webrick

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+gem "webrick"


### PR DESCRIPTION
Bug:
bundle exec jekyll serve fails with the following stack trace: /home/argilo/.gem/ruby/3.0.0/gems/jekyll-4.2.0/lib/jekyll/commands/serve/servlet.rb:3:in `require': cannot load such file -- webrick (LoadError) ....

Cause:
This happens because webrick is no longer a bundled gem in Ruby 3.0. 

Solution:
Adding gem "webrick" to my Gemfile solves the problem

Reference: 
https://github.com/jekyll/jekyll/issues/8523